### PR TITLE
Bugfix: Scanning for Meet-Conflicts

### DIFF
--- a/src/cpp/hpetrisim/HSimulation.cpp
+++ b/src/cpp/hpetrisim/HSimulation.cpp
@@ -425,7 +425,7 @@ void CHSimulation::Online()
 					continue;
 				}
 
-				if (pCon->From()->ConnectorsIn().GetCount() > 1)
+				if (pCon->To()->ConnectorsIn().GetCount() > 1)
 				{
 					pTran->Enabled(true);
 					pTran->Invalid(true);


### PR DESCRIPTION
A meet conflict can only occur, when multiple input connectors are connected to the ouput postion. But the code scans for multiple input connectors that are connected to the source transition.